### PR TITLE
지도 API 연동 기능 구현

### DIFF
--- a/src/main/java/com/cocoballdiary/controller/FileController.java
+++ b/src/main/java/com/cocoballdiary/controller/FileController.java
@@ -61,7 +61,7 @@ public class FileController {
 
                         File thumbFile = new File(uploadPath, "s_" + uuid + "_" + originalName);
 
-                        Thumbnailator.createThumbnail(savePath.toFile(), thumbFile, 200, 200);
+                        Thumbnailator.createThumbnail(savePath.toFile(), thumbFile, 400, 400);
                     }
 
                 } catch (IOException e) {

--- a/src/main/resources/templates/diary/list.html
+++ b/src/main/resources/templates/diary/list.html
@@ -47,7 +47,7 @@
             <div class="card shadow-sm">
               <div class="card" th:if="${dto.images != null && dto.images.size() > 0}">
                 <img class="card-img-top"
-                     th:src="|/view/s_${dto.images[0].uuid}_${dto.images[0].fileName}|" height="225">
+                     th:src="|/view/s_${dto.images[0].uuid}_${dto.images[0].fileName}|" height="300">
               </div>
               <svg th:if="${dto.images == null || dto.images.size() == 0}" class="bd-placeholder-img card-img-top"
                    width="100%" height="225" xmlns="http://www.w3.org/2000/svg"

--- a/src/main/resources/templates/diary/modify.html
+++ b/src/main/resources/templates/diary/modify.html
@@ -29,7 +29,7 @@
             <li class="list-group-item">
               <div>
                 <h6 class="my-0">주소</h6>
-                <input type="text" class="form-control" name="address" id="address" placeholder="주소" th:value="${dto.address}" required>
+                <input type="text" class="form-control" name="address" id="address" placeholder="도로명 / 지번 주소" th:value="${dto.address}" required>
                 <div class="invalid-feedback">
                   주소를 적어주세요.
                 </div>
@@ -137,7 +137,7 @@
         </div>
         <div class="modal-body">
           <div class="input-group mb-3">
-            <input type="file" name="files" class="form-control" accept=".png, .jpeg" multiple>
+            <input type="file" name="files" class="form-control" accept=".png, .jpeg, .jpg" multiple>
           </div>
         </div>
         <div class="modal-footer">

--- a/src/main/resources/templates/diary/read.html
+++ b/src/main/resources/templates/diary/read.html
@@ -45,6 +45,9 @@
               </fieldset>
             </div>
           </li>
+          <div id="map" style="width:100%;height:350px;">
+
+          </div>
         </ul>
       </div>
 
@@ -170,6 +173,8 @@
   <script src="/js/comment.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"></script>
+
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=3de3d8a6bc873e2a21d462dedb5b6c64&libraries=services"></script>
 
   <script layout:fragment="script" th:inline="javascript">
 
@@ -434,5 +439,46 @@
               console.log(e)
           })
       }, false)
+
+      const placeAddress = [[${dto.address}]]
+
+      var mapContainer = document.getElementById('map'), // 지도를 표시할 div
+          mapOption = {
+              center: new kakao.maps.LatLng(33.450701, 126.570667), // 지도의 중심좌표
+              level: 3 // 지도의 확대 레벨
+          };
+
+      // 지도를 생성합니다
+      var map = new kakao.maps.Map(mapContainer, mapOption);
+
+      // 주소-좌표 변환 객체를 생성합니다
+      var geocoder = new kakao.maps.services.Geocoder();
+
+      // 주소로 좌표를 검색합니다
+      geocoder.addressSearch(placeAddress, function (result, status) {
+
+          // 정상적으로 검색이 완료됐으면
+          if (status === kakao.maps.services.Status.OK) {
+
+              var coords = new kakao.maps.LatLng(result[0].y, result[0].x);
+
+              // 결과값으로 받은 위치를 마커로 표시합니다
+              var marker = new kakao.maps.Marker({
+                  map: map,
+                  position: coords
+              });
+
+              // 인포윈도우로 장소에 대한 설명을 표시합니다
+              var infowindow = new kakao.maps.InfoWindow({
+                  content: '<div style="width:150px;text-align:center;padding:6px 0;">[[${dto.placeName}]]</div>'
+              });
+              infowindow.open(map, marker);
+
+              // 지도의 중심을 결과값으로 받은 위치로 이동시킵니다
+              map.setCenter(coords);
+          } else {
+              $("#map").hide();
+          }
+      });
 
   </script>

--- a/src/main/resources/templates/diary/write.html
+++ b/src/main/resources/templates/diary/write.html
@@ -29,7 +29,7 @@
             <li class="list-group-item">
               <div>
                 <h6 class="my-0">주소</h6>
-                <input type="text" class="form-control" name="address" id="address" placeholder="주소" required>
+                <input type="text" class="form-control" name="address" id="address" placeholder="도로명 / 지번 주소" required>
                 <div class="invalid-feedback">
                   주소를 적어주세요.
                 </div>
@@ -106,7 +106,7 @@
         </div>
         <div class="modal-body">
           <div class="input-group mb-3">
-            <input type="file" name="files" class="form-control" accept=".png, .jpeg" multiple>
+            <input type="file" name="files" class="form-control" accept=".png, .jpeg, .jpg" multiple>
           </div>
         </div>
         <div class="modal-footer">
@@ -121,7 +121,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/upload.js"></script>
   <script src="/js/form-validation.js"></script>
-
 
   <script layout:fragment="script" th:inline="javascript">
 


### PR DESCRIPTION
게시글 내에 카카오 지도 API를 연동하여 장소를 찍을 수 있도록 한다.
게시글 업로드 시 카카오 지도 검색 -> 장소 저장 -> 표시 이렇게 하려고 했으나
테스트를 해보니 장소가 여러 개 찍히는 경우가 많아서
일단은 사용자가 직접 주소를 복사해서 올려놓으면 자동으로 카카오 지도 표시를 해주는 것으로 구현 예정.

* [x] 주소 입력 시 지도 표시
* [x] 주소 저장 및 저장된 주소에 맞게 지도 표시

This closes #33 